### PR TITLE
✨RDS DatePicker features

### DIFF
--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -19,14 +19,14 @@ class DateInput extends PureComponent {
   componentDidUpdate(prevProps) {
     const { value } = prevProps;
 
-    if (!dayjs(value).isSame(this.props.value)) {
+    if (value && !value.isSame(this.props.value)) {
       this.setState({ value: this.formatDate(this.props) });
     }
   }
 
   formatDate({ value }) {
-    if (value && dayjs(value).isValid()) {
-      return dayjs(value).format('LL');
+    if (value && dayjs.isDayjs(value)) {
+      return value.format('LL');
     }
     return '';
   }
@@ -98,13 +98,15 @@ DateInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
   onFocus: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  now: PropTypes.object,
 };
 
 DateInput.defaultProps = {
   readOnly: true,
   disabled: false,
-  dateDisplayFormat: 'MMM D, YYYY'
+  dateDisplayFormat: 'MMM D, YYYY',
+  now: dayjs(),
 };
 
 export default DateInput;

--- a/src/components/DateRange/README.md
+++ b/src/components/DateRange/README.md
@@ -11,15 +11,16 @@ This component extends all the props of **[Calendar](#calendar)** component. In 
 
 #### Example: Editable Date Inputs
 ```jsx inside Markdown
-import {useState} from 'react'
+import {useState} from 'react';
+import dayjs from 'dayjs';
+
 const [state, setState] = useState([
     {
-      startDate: new Date(),
+      startDate: dayjs(),
       endDate: null,
       key: 'selection'
     }
   ]);
-  
 <DateRange
   editableDateInputs={true}
   onChange={item => setState([item.selection])}

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -28,34 +28,38 @@ class DateRange extends Component {
       moveRangeOnFirstSelection,
       retainEndDateOnFirstSelection,
       disabledDates,
+      now,
     } = this.props;
     const focusedRangeIndex = focusedRange[0];
     const selectedRange = ranges[focusedRangeIndex];
     if (!selectedRange || !onChange) return {};
     let { startDate, endDate } = selectedRange;
-    const now = dayjs();
     let nextFocusRange;
     if (!isSingleValue) {
       startDate = value.startDate;
       endDate = value.endDate;
     } else if (focusedRange[1] === 0) {
       // startDate selection
-      const dayOffset = dayjs(endDate || now).diff(startDate, 'day');
+      const dayOffset = (endDate || now)
+        .diff(startDate, 'day');
       const calculateEndDate = () => {
         if (moveRangeOnFirstSelection) {
-          return dayjs(value).add(dayOffset, 'day');
+          return value.add(dayOffset, 'day');
         }
         if (retainEndDateOnFirstSelection) {
-          if (!endDate || dayjs(value).isBefore(dayjs(endDate), 'day')) {
-            return dayjs(endDate);
+          if (
+            !endDate ||
+            value.isBefore(endDate, 'day')
+          ) {
+            return endDate;
           }
-          return dayjs(value);
+          return value;
         }
-        return dayjs(value) || dayjs();
+        return value || now;
       };
       startDate = value;
       endDate = calculateEndDate();
-      if (maxDate) endDate = dayjs.min([dayjs(endDate), dayjs(maxDate)]);
+      if (maxDate) endDate = dayjs.min([endDate, maxDate]);
       nextFocusRange = [focusedRange[0], 1];
     } else {
       endDate = value;
@@ -122,6 +126,7 @@ class DateRange extends Component {
   render() {
     return (
       <Calendar
+        now={this.props.now}
         focusedRange={this.state.focusedRange}
         onRangeFocusChange={this.handleRangeFocusChange}
         preview={this.state.preview}
@@ -148,6 +153,7 @@ DateRange.defaultProps = {
   retainEndDateOnFirstSelection: false,
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   disabledDates: [],
+  now: dayjs(),
 };
 
 DateRange.propTypes = {
@@ -158,6 +164,7 @@ DateRange.propTypes = {
   ranges: PropTypes.arrayOf(rangeShape),
   moveRangeOnFirstSelection: PropTypes.bool,
   retainEndDateOnFirstSelection: PropTypes.bool,
+  now: PropTypes.object,
 };
 
 export default DateRange;

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -32,7 +32,7 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState([
   {
-    startDate: new Date(),
+    startDate: dayjs(),
     endDate: dayjs().add(7, 'day'),
     key: 'selection'
   }
@@ -58,12 +58,12 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection: {
-    startDate: new Date(),
+    startDate: dayjs(),
     endDate: null,
     key: 'selection'
   },
   compare: {
-    startDate: new Date(),
+    startDate: dayjs(),
     endDate: dayjs().add(3, 'day'),
     key: 'compare'
   }
@@ -232,7 +232,7 @@ const [state, setState] = useState({
     key: 'selection'
   },
   compare: {
-    startDate: new Date(),
+    startDate: dayjs(),
     endDate: dayjs().add(3, 'day'),
     key: 'compare'
   }
@@ -246,5 +246,41 @@ const [state, setState] = useState({
   direction="vertical"
   scroll={{ enabled: true }}
   ranges={[state.selection, state.compare]}
+/>;
+```
+
+#### Example: Custom current date (now)
+
+Provide custom current date, useful when the context is related to a custom
+timezone where the current date could be the next or previous date of the actual user date.
+
+```jsx inside Markdown
+import { useState } from 'react';
+import dayjs from 'dayjs';
+
+const now = dayjs().add(40, 'day');
+
+const [state, setState] = useState({
+  selection: {
+    startDate: now,
+    endDate: null,
+    key: 'selection'
+  },
+  compare: {
+    startDate: now,
+    endDate: now.add(3, 'day'),
+    key: 'compare'
+  }
+});
+
+<DateRangePicker
+  onChange={item => setState({ ...state, ...item })}
+  months={1}
+  scroll={{ enabled: false }}
+  direction="vertical"
+  minDate={now.subtract(50, 'day')}
+  maxDate={now.add(30, 'day')}
+  ranges={[state.selection, state.compare]}
+  now={now}
 />;
 ```

--- a/src/components/DateRangePicker/index.js
+++ b/src/components/DateRangePicker/index.js
@@ -5,6 +5,8 @@ import DefinedRange from '../DefinedRange';
 import { findNextRangeIndex, generateStyles } from '../../utils';
 import classnames from 'classnames';
 import coreStyles from '../../styles';
+import dayjs from 'dayjs';
+import { defaultInputRanges, defaultStaticRanges } from '../../defaultRanges';
 
 class DateRangePicker extends Component {
   constructor(props) {
@@ -16,9 +18,15 @@ class DateRangePicker extends Component {
   }
   render() {
     const { focusedRange } = this.state;
+    // All calendar calculations are based on the current date aka `now`. However, operations with dayjs() objects
+    // with timezone properties are costly and slow, visible when interacting with the UI; one hack is to do the
+    // conversion, remove the timezone and convert it back to a simple dayjs object. Here, we are removing the timezone
+    // data in case it's provided.
+    // Possible cause: https://github.com/iamkun/dayjs/issues/1236
+    const now = dayjs((this.props.now || dayjs()).format('YYYY-MM-DD'));
     return (
       <div className={classnames(this.styles.dateRangePickerWrapper, this.props.className)}>
-        <DefinedRange
+        {<DefinedRange
           focusedRange={focusedRange}
           onPreviewChange={value =>
             this.dateRange.updatePreview(
@@ -28,20 +36,26 @@ class DateRangePicker extends Component {
           {...this.props}
           range={this.props.ranges[focusedRange[0]]}
           className={undefined}
-        />
+          now={now}
+          inputRanges={defaultInputRanges(now)}
+          staticRanges={defaultStaticRanges(now)}
+        />}
         <DateRange
           onRangeFocusChange={focusedRange => this.setState({ focusedRange })}
           focusedRange={focusedRange}
           {...this.props}
           ref={t => (this.dateRange = t)}
           className={undefined}
+          now={now}
         />
       </div>
     );
   }
 }
 
-DateRangePicker.defaultProps = {};
+DateRangePicker.defaultProps = {
+  now: dayjs(),
+};
 
 DateRangePicker.propTypes = {
   ...DateRange.propTypes,

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -90,16 +90,16 @@ class DayCell extends Component {
   renderPreviewPlaceholder = () => {
     const { preview, day, styles } = this.props;
     if (!preview) return null;
-    if (dayjs(preview.startDate).isAfter(dayjs(preview.endDate))) {
+    if (preview.startDate.isAfter(preview.endDate)) {
       const start = preview.startDate;
       preview.startDate = preview.endDate;
       preview.endDate = start;
     }
-    const startDate = preview.startDate ? dayjs(preview.startDate) : null;
-    const endDate = preview.endDate ? dayjs(preview.endDate) : null;
-    const isInRange = dayjs(day).isBetween(startDate, endDate, 'day');
-    const isStartEdge = !isInRange && dayjs(day).isSame(startDate, 'day');
-    const isEndEdge = !isInRange && dayjs(day).isSame(endDate, 'day');
+    const startDate = preview.startDate ? preview.startDate : null;
+    const endDate = preview.endDate ? preview.endDate : null;
+    const isInRange = day.isBetween(startDate, endDate, 'day');
+    const isStartEdge = !isInRange && day.isSame(startDate, 'day');
+    const isEndEdge = !isInRange && day.isSame(endDate, 'day');
     return (
       <span
         className={classnames({
@@ -112,25 +112,25 @@ class DayCell extends Component {
     );
   };
   renderSelectionPlaceholders = () => {
-    const { styles, ranges, day } = this.props;
-    if (this.props.displayMode === 'date') {
-      let isSelected = dayjs(this.props.day).isSame(this.props.date, 'day');
-      return isSelected ? <span className={styles.selected} style={{ color: this.props.color }} /> : null;
+    const { styles, ranges, day, displayMode, date, color, now } = this.props;
+    if (displayMode === 'date') {
+      let isSelected = day.isSame(date, 'day');
+      return isSelected ? <span className={styles.selected} style={{ color }} /> : null;
     }
 
     const inRanges = ranges.reduce((result, range) => {
-      let startDate = dayjs(range.startDate);
-      let endDate = dayjs(range.endDate);
-      if (endDate.isBefore(startDate, 'day')) {
+      let startDate = range.startDate || now;
+      let endDate = range.endDate || now;
+      if (endDate?.isBefore(startDate, 'day')) {
         [startDate, endDate] = [endDate, startDate];
       }
-      startDate = startDate ? dayjs(startDate).endOf('day') : null;
-      endDate = endDate ? dayjs(endDate).startOf('day') : null;
+      startDate = startDate ? startDate.endOf('day') : null;
+      endDate = endDate ? endDate.startOf('day') : null;
       const isInRange =
-        (!startDate || dayjs(day).isAfter(startDate, 'day')) &&
-        (!endDate || dayjs(day).isBefore(endDate, 'day'));
-      const isStartEdge = !isInRange && dayjs(day).isSame(startDate, 'day');
-      const isEndEdge = !isInRange && dayjs(day).isSame(endDate, 'day');
+        (!startDate || day.isAfter(startDate, 'day')) &&
+        (!endDate || day.isBefore(endDate, 'day'));
+      const isStartEdge = !isInRange && day.isSame(startDate, 'day');
+      const isEndEdge = !isInRange && day.isSame(endDate, 'day');
       if (isInRange || isStartEdge || isEndEdge) {
         return [
           ...result,
@@ -179,14 +179,16 @@ class DayCell extends Component {
         {this.renderSelectionPlaceholders()}
         {this.renderPreviewPlaceholder()}
         <span className={this.props.styles.dayNumber}>
-          {dayContentRenderer?.(this.props.day) || <span>{dayjs(this.props.day).date()}</span>}
+          {dayContentRenderer?.(this.props.day) || <span>{this.props.day.date()}</span>}
         </span>
       </button>
     );
   }
 }
 
-DayCell.defaultProps = {};
+DayCell.defaultProps = {
+  now: dayjs(),
+};
 
 export const rangeShape = PropTypes.shape({
   startDate: PropTypes.object,
@@ -225,6 +227,7 @@ DayCell.propTypes = {
   onMouseUp: PropTypes.func,
   onMouseEnter: PropTypes.func,
   dayContentRenderer: PropTypes.func,
+  now: PropTypes.object
 };
 
 export default DayCell;

--- a/src/components/DefinedRange/index.js
+++ b/src/components/DefinedRange/index.js
@@ -5,6 +5,7 @@ import { defaultInputRanges, defaultStaticRanges } from '../../defaultRanges';
 import { rangeShape } from '../DayCell';
 import InputRangeField from '../InputRangeField';
 import cx from 'classnames';
+import dayjs from 'dayjs';
 
 class DefinedRange extends Component {
   constructor(props) {
@@ -129,11 +130,12 @@ DefinedRange.propTypes = {
   rangeColors: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   renderStaticRangeLabel: PropTypes.func,
+  now: PropTypes.object,
 };
 
 DefinedRange.defaultProps = {
-  inputRanges: defaultInputRanges,
-  staticRanges: defaultStaticRanges,
+  inputRanges: defaultInputRanges(dayjs()),
+  staticRanges: defaultStaticRanges(dayjs()),
   ranges: [],
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   focusedRange: [0, 0],

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -9,12 +9,14 @@ import DayCell, { rangeShape } from '../DayCell';
 
 dayjs.extend(weekday);
 // eslint-disable-next-line no-unused-vars
-function renderWeekdays(styles, _dateOptions, _weekdayDisplayFormat) {
+function renderWeekdays(now, styles, _dateOptions, _weekdayDisplayFormat) {
+  const startOfWeek = now.startOf('isoWeek');
+  const endOfWeek = now.endOf('isoWeek');
   return (
     <div className={styles.weekDays}>
-      {getIntervals(dayjs().startOf('isoWeek'), dayjs().endOf('isoWeek')).map((day, i) => (
+      {getIntervals(startOfWeek, endOfWeek).map((day, i) => (
         <span className={styles.weekDay} key={i}>
-          {dayjs.weekdaysShort()[dayjs(day).weekday()]}
+          {dayjs.weekdaysShort()[day.weekday()]}
         </span>
       ))}
     </div>
@@ -23,10 +25,9 @@ function renderWeekdays(styles, _dateOptions, _weekdayDisplayFormat) {
 
 class Month extends PureComponent {
   render() {
-    const now = dayjs();
-    const { displayMode, focusedRange, drag, styles, disabledDates, disabledDay } = this.props;
-    const minDate = this.props.minDate && dayjs(this.props.minDate).startOf('day');
-    const maxDate = this.props.maxDate && dayjs(this.props.maxDate).endOf('day');
+    const { displayMode, focusedRange, drag, styles, disabledDates, disabledDay, now } = this.props;
+    const minDate = this.props.minDate?.startOf('day');
+    const maxDate = this.props.maxDate?.endOf('day');
     const monthDisplay = getMonthDisplayRange(
       this.props.month,
       this.props.dateOptions,
@@ -51,10 +52,14 @@ class Month extends PureComponent {
           <div className={styles.monthName}>{dayjs.months()[this.props.month.month()]}</div>
         ) : null}
         {this.props.showWeekDays &&
-          renderWeekdays(styles, this.props.dateOptions, this.props.weekdayDisplayFormat)}
+          renderWeekdays(
+            now,
+            styles,
+            this.props.dateOptions,
+            this.props.weekdayDisplayFormat,
+          )}
         <div className={styles.days} onMouseLeave={this.props.onMouseLeave}>
-          {getIntervals(monthDisplay.start, monthDisplay.end).map((dayNotParsed, index) => {
-            const day = dayjs(dayNotParsed);
+          {getIntervals(monthDisplay.start, monthDisplay.end).map((day, index) => {
             const isStartOfMonth = day.isSame(monthDisplay.startDateOfMonth, 'day');
             const isEndOfMonth = day.isSame(monthDisplay.endDateOfMonth, 'day');
             const isOutsideMinMax =
@@ -68,6 +73,7 @@ class Month extends PureComponent {
                 {...this.props}
                 ranges={ranges}
                 day={day}
+                now={now}
                 preview={showPreview ? this.props.preview : null}
                 isWeekend={day.isoWeekday() == 7 || day.isoWeekday() == 6}
                 isToday={day.isSame(now, 'day')}
@@ -99,7 +105,9 @@ class Month extends PureComponent {
   }
 }
 
-Month.defaultProps = {};
+Month.defaultProps = {
+  now: dayjs(),
+};
 
 Month.propTypes = {
   style: PropTypes.object,
@@ -129,6 +137,7 @@ Month.propTypes = {
   showWeekDays: PropTypes.bool,
   showMonthName: PropTypes.bool,
   fixedHeight: PropTypes.bool,
+  now: PropTypes.object,
 };
 
 export default Month;

--- a/src/defaultRanges.js
+++ b/src/defaultRanges.js
@@ -1,31 +1,31 @@
 import dayjs from 'dayjs';
 
-const defineds = {
-  startOfWeek: dayjs().startOf('isoWeek'),
-  endOfWeek: dayjs().endOf('isoWeek'),
-  startOfLastWeek: dayjs()
+const defineds = (now = dayjs()) => ({
+  startOfWeek: now.startOf('isoWeek'),
+  endOfWeek: now.endOf('isoWeek'),
+  startOfLastWeek: now
     .subtract(7, 'day')
     .startOf('day'),
-  endOfLastWeek: dayjs()
+  endOfLastWeek: now
     .subtract(7, 'day')
     .endOf('isoWeek'),
-  startOfToday: dayjs().startOf('day'),
-  endOfToday: dayjs().endOf('day'),
-  startOfYesterday: dayjs()
+  startOfToday: now.startOf('day'),
+  endOfToday: now.endOf('day'),
+  startOfYesterday: now
     .subtract(1, 'day')
     .startOf('day'),
-  endOfYesterday: dayjs()
+  endOfYesterday: now
     .subtract(1, 'day')
     .endOf('day'),
-  startOfMonth: dayjs().startOf('month'),
-  endOfMonth: dayjs().endOf('month'),
-  startOfLastMonth: dayjs()
+  startOfMonth: now.startOf('month'),
+  endOfMonth: now.endOf('month'),
+  startOfLastMonth: now
     .subtract(1, 'month')
     .startOf('month'),
-  endOfLastMonth: dayjs()
+  endOfLastMonth: now
     .subtract(1, 'month')
     .endOf('month'),
-};
+});
 
 const staticRangeHandler = {
   range: {},
@@ -42,7 +42,7 @@ export function createStaticRanges(ranges) {
   return ranges.map(range => ({ ...staticRangeHandler, ...range }));
 }
 
-export const defaultStaticRanges = createStaticRanges([
+export const defaultStaticRanges = (now = dayjs()) => ((defineds) => createStaticRanges([
   {
     label: 'Today',
     range: () => ({
@@ -86,9 +86,9 @@ export const defaultStaticRanges = createStaticRanges([
       endDate: defineds.endOfLastMonth,
     }),
   },
-]);
+]))(defineds(now));
 
-export const defaultInputRanges = [
+export const defaultInputRanges = (now = dayjs()) => ((defineds) => [
   {
     label: 'days up to today',
     range(value) {
@@ -118,4 +118,4 @@ export const defaultInputRanges = [
       return dayjs(range.endDate).diff(defineds.startOfToday, 'day') + 1;
     },
   },
-];
+])(defineds(now));

--- a/src/theme/default.scss
+++ b/src/theme/default.scss
@@ -394,3 +394,8 @@
   color: #849095;
   padding: 0.833em;
 }
+
+/* Hide days not belonging to the current month */
+.rdrDayPassive {
+  visibility: hidden;
+}

--- a/src/theme/default.scss
+++ b/src/theme/default.scss
@@ -259,6 +259,25 @@
  }
 }
 
+/** If hovered day is at the right edge and is inside/start of a preview day range, remove border right radius **/
+.rdrDayEndOfMonth, .rdrDayEndOfWeek{
+  .rdrDayInPreview, .rdrDayStartPreview:not(.rdrDayEndPreview) {
+   border-top-right-radius: 0;
+   border-bottom-right-radius:  0;
+   border-right-width: 1px;
+   right: 0px;
+ }
+}
+
+/** If hovered day is at the left edge and is inside/end of a preview day range, remove border left radius **/
+.rdrDayStartOfMonth, .rdrDayStartOfWeek{
+  .rdrDayInPreview, .rdrDayEndPreview:not(.rdrDayStartPreview) {
+   border-top-left-radius:  0;
+   border-bottom-left-radius:  0;
+   border-left-width: 1px;
+   left: 0px;
+ }
+}
 
 .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview{
   background: rgba(255, 255, 255, 0.09);
@@ -398,4 +417,17 @@
 /* Hide days not belonging to the current month */
 .rdrDayPassive {
   visibility: hidden;
+}
+
+/* Border radius only applied to multi-day ranges edges, no radius to days in-between */
+.rdrInRange {
+  border-radius: 0 !important;
+}
+.rdrStartEdge:not(.rdrEndEdge) {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+.rdrEndEdge:not(.rdrStartEdge) {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,7 @@
 import classnames from 'classnames';
-import dayjs from 'dayjs';
 
 export function calcFocusDate(currentFocusedDate, props) {
-  const { shownDate, date, months, ranges, focusedRange, displayMode } = props;
+  const { shownDate, date, months, ranges, focusedRange, displayMode, now } = props;
   // find primary date according the props
   let targetInterval;
   if (displayMode === 'dateRange') {
@@ -17,9 +16,9 @@ export function calcFocusDate(currentFocusedDate, props) {
       end: date,
     };
   }
-  targetInterval.start = (dayjs(targetInterval.start) || dayjs()).startOf('month');
-  targetInterval.end = (dayjs(targetInterval.end) || dayjs(targetInterval.start)).endOf('month');
-  const targetDate = targetInterval.start || targetInterval.end || shownDate || dayjs();
+  targetInterval.start = (targetInterval.start || now).startOf('month');
+  targetInterval.end = (targetInterval.end || targetInterval.start).endOf('month');
+  const targetDate = targetInterval.start || targetInterval.end || shownDate || now;
 
   // initial focus
   if (!currentFocusedDate) return shownDate || targetDate;
@@ -42,8 +41,8 @@ export function findNextRangeIndex(ranges, currentRangeIndex = -1) {
 }
 
 export function getMonthDisplayRange(date, dateOptions, fixedHeight) {
-  const startDateOfMonth = dayjs(date).startOf('month');
-  const endDateOfMonth = dayjs(date).endOf('month');
+  const startDateOfMonth = date.startOf('month');
+  const endDateOfMonth = date.endOf('month');
   const startDateOfCalendar = startDateOfMonth.startOf('isoWeek');
   let endDateOfCalendar = endDateOfMonth.endOf('isoWeek');
   if (fixedHeight && endDateOfCalendar.diff(startDateOfCalendar, 'day') <= 34) {
@@ -72,11 +71,11 @@ export function generateStyles(sources) {
 }
 
 export function getIntervals(currentDay, closeDay) {
-  var currentDate = dayjs(currentDay);
-  var closeTime = dayjs(closeDay);
+  var currentDate = currentDay;
+  var closeTime = closeDay;
   const dateRanges = [];
   while (currentDate.isBefore(closeTime, 'day') || currentDate.isSame(closeTime, 'day')) {
-    dateRanges.push(currentDate.format());
+    dateRanges.push(currentDate.clone());
     currentDate = currentDate.add(1, 'day');
   }
   return dateRanges;


### PR DESCRIPTION
### ✨Add `now` property
- Remove all `dayjs()` calls which converts provided input to the local timezone.
- Remove unnecesary `dayjs()` calls across different components, all of them now use `dayjs` instances already.
- Update examples to use `dayjs` instances instead of `Date`.
- Provide custom current date via the `now` property, useful when the context is related to a custom explicit timezone (timezone selector) where the current date could be the next or previous date of the actual user date.
- Update `defaultRanges` to use `now` as relative day.

### ✨Remove border radius from in-between days
![image](https://github.com/tolares/react-date-range-dayjs/assets/1231888/a366b7f9-e68d-443c-b840-6faceddd9e1e)
![image](https://github.com/tolares/react-date-range-dayjs/assets/1231888/a08366d7-8889-4202-941b-5a2d72f277a9)

### ✨Hide days not belonging to the current visible month
![image](https://github.com/tolares/react-date-range-dayjs/assets/1231888/6b4dee17-7441-41a4-8f3e-9d24f5f3098b)



## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
- Using `dayjs.tz()` is costly; instead, providing a custom `now` works well.
- Changes required to have same UX as current DatePicker in prod for the new RDS DatePicker.
- WIP, pending to test together with new RDS DatePicker.