### PR TITLE
✨Add range `textColor` property

### DIFF
--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -284,3 +284,41 @@ const [state, setState] = useState({
   now={now}
 />;
 ```
+
+#### Example: Custom range textColor
+
+When providing a range color, sometimes we need better contrast with the date text
+which by default is white, we can customize it by setting the `textColor` range property.
+
+```jsx inside Markdown
+import { useState } from 'react';
+import dayjs from 'dayjs';
+
+const now = dayjs().add(40, 'day');
+
+const [state, setState] = useState({
+  selection: {
+    startDate: now,
+    endDate: now.add(3, 'day'),
+    key: 'selection',
+  },
+  compare: {
+    startDate: now.subtract(1, 'week'),
+    endDate: now.add(3, 'day').subtract(1, 'week'),
+    key: 'compare',
+    textColor: 'black',
+    color: '#EEE'
+  }
+});
+
+<DateRangePicker
+  onChange={item => setState({ ...state, ...item })}
+  months={1}
+  scroll={{ enabled: false }}
+  direction="vertical"
+  minDate={now.subtract(50, 'day')}
+  maxDate={now.add(30, 'day')}
+  ranges={[state.selection, state.compare]}
+  now={now}
+/>;
+```


### PR DESCRIPTION
- When providing a range color, sometimes we need better contrast with the date text which by default is white, we can customize it by setting the `textColor` range property.

Example:

```
import { useState } from 'react';
import dayjs from 'dayjs';

const now = dayjs().add(40, 'day');

const [state, setState] = useState({
  selection: {
    startDate: now,
    endDate: now.add(3, 'day'),
    key: 'selection',
  },
  compare: {
    startDate: now.subtract(1, 'week'),
    endDate: now.add(3, 'day').subtract(1, 'week'),
    key: 'compare',
    textColor: 'black',
    color: '#EEE'
  }
});

<DateRangePicker
  onChange={item => setState({ ...state, ...item })}
  months={1}
  scroll={{ enabled: false }}
  direction="vertical"
  minDate={now.subtract(50, 'day')}
  maxDate={now.add(30, 'day')}
  ranges={[state.selection, state.compare]}
  now={now}
/>;
```

Result:
![image](https://github.com/tolares/react-date-range-dayjs/assets/1231888/0b80285e-51f6-4c6c-8958-9ddd910f73d1)


## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

> Related Issue: #xxx