### PR TITLE
🐛 Fixes and improvements

### DIFF
--- a/src/components/Calendar/README.md
+++ b/src/components/Calendar/README.md
@@ -10,14 +10,20 @@ const [state, setState] = useState([
       startDate: dayjs().utc(true),
       endDate:  dayjs().utc(true),
       color: '#000',
-      textColor: 'red'
+      textColor: 'red',
+      key: 'selection'
     }
   ]);
 
 <Calendar
+  dragSelectionEnabled={false}
   showDateDisplay={false}
   displayMode="dateRange"
-  onChange={item => {}}
+  onChange={item => setState([{
+    startDate: item,
+    endDate: item,
+    key:'selection'
+  }])}
   ranges={state}
   maxDate={dayjs().utc(true)}
   weekStartsOn={0}

--- a/src/components/Calendar/README.md
+++ b/src/components/Calendar/README.md
@@ -1,0 +1,26 @@
+#### Example: Basic Calendar
+```jsx inside Markdown
+import {useState} from 'react';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);
+
+const [state, setState] = useState([
+    {
+      startDate: dayjs(),
+      endDate:  dayjs(),
+      color: '#000',
+      textColor: 'red'
+    }
+  ]);
+
+<Calendar
+  readOnly
+  showDateDisplay={false}
+  displayMode="dateRange"
+  onChange={item => {}}
+  ranges={state}
+  maxDate={dayjs()}
+  weekStartsOn={0}
+  locale="fr"
+/>

--- a/src/components/Calendar/README.md
+++ b/src/components/Calendar/README.md
@@ -7,20 +7,19 @@ dayjs.extend(utc);
 
 const [state, setState] = useState([
     {
-      startDate: dayjs(),
-      endDate:  dayjs(),
+      startDate: dayjs().utc(true),
+      endDate:  dayjs().utc(true),
       color: '#000',
       textColor: 'red'
     }
   ]);
 
 <Calendar
-  readOnly
   showDateDisplay={false}
   displayMode="dateRange"
   onChange={item => {}}
   ranges={state}
-  maxDate={dayjs()}
+  maxDate={dayjs().utc(true)}
   weekStartsOn={0}
   locale="fr"
 />

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,9 +1,18 @@
+import 'dayjs/locale/de';
+import 'dayjs/locale/es';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/it';
+import 'dayjs/locale/ja';
+import 'dayjs/locale/nl';
+import 'dayjs/locale/pt';
+import 'dayjs/locale/ru';
 import { shallowEqualObjects } from 'shallow-equal';
 import classnames from 'classnames';
 import dayjs from 'dayjs';
 import localeData from 'dayjs/plugin/localeData';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import minMax from 'dayjs/plugin/minMax';
+import updateLocale from 'dayjs/plugin/updateLocale';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactList from 'react-list';
@@ -18,12 +27,20 @@ import Month from '../Month';
 dayjs.extend(localeData);
 dayjs.extend(minMax);
 dayjs.extend(localizedFormat);
+dayjs.extend(updateLocale);
 
 class Calendar extends PureComponent {
   constructor(props, context) {
     super(props, context);
     this.dateOptions = { locale: props.locale };
     if (props.weekStartsOn !== undefined) this.dateOptions.weekStartsOn = props.weekStartsOn;
+    if (this.dateOptions.weekStartsOn != null) {
+      dayjs.updateLocale(this.dateOptions.locale, {
+        weekStart: this.dateOptions.weekStartsOn,
+      });
+      this.props.now.$locale().weekStart = this.dateOptions.weekStartsOn;
+    }
+    dayjs.locale(this.dateOptions.locale);
     this.styles = generateStyles([coreStyles, props.classNames]);
     this.listSizeCache = {};
     this.isFirstRender = true;
@@ -126,6 +143,13 @@ class Calendar extends PureComponent {
     if (prevProps.locale !== this.props.locale || prevProps.weekStartsOn !== this.props.weekStartsOn) {
       this.dateOptions = { locale: this.props.locale };
       if (this.props.weekStartsOn !== undefined) this.dateOptions.weekStartsOn = this.props.weekStartsOn;
+      if (this.dateOptions.weekStartsOn != null) {
+        dayjs.updateLocale(this.dateOptions.locale, {
+          weekStart: this.dateOptions.weekStartsOn,
+        });
+       this.props.now.$locale().weekStart = this.dateOptions.weekStartsOn;
+      }
+      dayjs.locale(this.dateOptions.locale);
       this.setState({
         monthNames: this.getMonthNames()
       });
@@ -240,14 +264,14 @@ class Calendar extends PureComponent {
     );
   };
   renderWeekdays() {
-    let currentDate = this.props.now.startOf('isoWeek');
-    const closeTime = this.props.now.endOf('isoWeek');
+    let currentDate = this.props.now.startOf('week');
+    const closeTime = this.props.now.endOf('week');
     const dateRanges = getIntervals(currentDate, closeTime);
     return (
       <div className={this.styles.weekDays}>
         {dateRanges.map((day, i) => (
           <span className={this.styles.weekDay} key={i}>
-            { dayjs.weekdaysShort()[day.weekday()] }
+            {dayjs.weekdaysShort()[day.day()]}
           </span>
         ))}
       </div>
@@ -394,7 +418,6 @@ class Calendar extends PureComponent {
       navigatorRenderer,
       className,
       preview,
-      readOnly
     } = this.props;
     const { scrollArea, focusedDate } = this.state;
     const isVertical = direction === 'vertical';

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -12,6 +12,7 @@ import { rangeShape } from '../DayCell';
 import coreStyles from '../../styles';
 import DateInput from '../DateInput';
 import Month from '../Month';
+import styles from '../../styles';
 
 
 class Calendar extends PureComponent {
@@ -416,7 +417,10 @@ class Calendar extends PureComponent {
     }));
     return (
       <div
-        className={classnames(this.styles.calendarWrapper, className)}
+        className={classnames(this.styles.calendarWrapper, className,
+          {
+            [styles.calendarWrapperDragging]: this.state.drag
+          })}
         onMouseUp={() => {
           if(readOnly) return;
           this.setState({ drag: { status: false, range: {} } })}

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,37 +1,23 @@
-import 'dayjs/locale/de';
-import 'dayjs/locale/es';
-import 'dayjs/locale/fr';
-import 'dayjs/locale/it';
-import 'dayjs/locale/ja';
-import 'dayjs/locale/nl';
-import 'dayjs/locale/pt';
-import 'dayjs/locale/ru';
+
 import { shallowEqualObjects } from 'shallow-equal';
 import classnames from 'classnames';
-import dayjs from 'dayjs';
-import localeData from 'dayjs/plugin/localeData';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
-import minMax from 'dayjs/plugin/minMax';
-import updateLocale from 'dayjs/plugin/updateLocale';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactList from 'react-list';
 
+import dayjs from './../../timeEngine';
 import { ariaLabelsShape } from '../../accessibility';
-import { calcFocusDate, generateStyles, getMonthDisplayRange, getIntervals } from '../../utils';
+import { calcFocusDate, generateStyles, getMonthDisplayRange, getIntervals, checkProps } from '../../utils';
 import { rangeShape } from '../DayCell';
 import coreStyles from '../../styles';
 import DateInput from '../DateInput';
 import Month from '../Month';
 
-dayjs.extend(localeData);
-dayjs.extend(minMax);
-dayjs.extend(localizedFormat);
-dayjs.extend(updateLocale);
 
 class Calendar extends PureComponent {
   constructor(props, context) {
     super(props, context);
+    checkProps(props, 'Calendar')
     this.dateOptions = { locale: props.locale };
     if (props.weekStartsOn !== undefined) this.dateOptions.weekStartsOn = props.weekStartsOn;
     if (this.dateOptions.weekStartsOn != null) {
@@ -561,8 +547,8 @@ Calendar.defaultProps = {
     enabled: false
   },
   direction: 'vertical',
-  maxDate: dayjs().add(20, 'year'),
-  minDate: dayjs().subtract(100, 'year'),
+  maxDate: dayjs().utc(true).add(20, 'year'),
+  minDate: dayjs().utc(true).subtract(100, 'year'),
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   startDatePlaceholder: 'Early',
   endDatePlaceholder: 'Continuous',
@@ -572,7 +558,7 @@ Calendar.defaultProps = {
   calendarFocus: 'forwards',
   preventSnapRefocus: false,
   ariaLabels: {},
-  now: dayjs(),
+  now: dayjs().utc(true),
   readOnly: false,
 };
 

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -404,6 +404,7 @@ class Calendar extends PureComponent {
       navigatorRenderer,
       className,
       preview,
+      readOnly,
     } = this.props;
     const { scrollArea, focusedDate } = this.state;
     const isVertical = direction === 'vertical';

--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -102,7 +102,7 @@ DateInput.defaultProps = {
   readOnly: true,
   disabled: false,
   dateDisplayFormat: 'MMM D, YYYY',
-  now: dayjs(),
+  now: dayjs().utc(true),
 };
 
 export default DateInput;

--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -1,10 +1,8 @@
 import classnames from 'classnames';
-import dayjs from 'dayjs';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import dayjs from '../../timeEngine';
 
-dayjs.extend(localizedFormat);
 class DateInput extends PureComponent {
   constructor(props, context) {
     super(props, context);

--- a/src/components/DateRange/README.md
+++ b/src/components/DateRange/README.md
@@ -16,7 +16,7 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState([
     {
-      startDate: dayjs(),
+      startDate: dayjs().utc(true),
       endDate: null,
       key: 'selection'
     }

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -1,18 +1,16 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import dayjs from 'dayjs';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import isBetween from 'dayjs/plugin/isBetween';
-import { findNextRangeIndex, generateStyles } from '../../utils';
+import { checkProps, findNextRangeIndex, generateStyles } from '../../utils';
 import { rangeShape } from '../DayCell';
 import Calendar from '../Calendar';
 import coreStyles from '../../styles';
-dayjs.extend(isSameOrBefore);
-dayjs.extend(isBetween);
+import dayjs from '../../timeEngine';
+
 class DateRange extends Component {
   constructor(props, context) {
     super(props, context);
+    checkProps(props, 'DateRange');
     this.state = {
       focusedRange: props.initialFocusedRange || [findNextRangeIndex(props.ranges), 0],
       preview: null,
@@ -153,7 +151,7 @@ DateRange.defaultProps = {
   retainEndDateOnFirstSelection: false,
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   disabledDates: [],
-  now: dayjs(),
+  now: dayjs().utc(true),
   readOnly: false,
 };
 

--- a/src/components/DateRange/index.test.js
+++ b/src/components/DateRange/index.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import dayjs from 'dayjs';
+import dayjs from '../../timeEngine';
 import DateRange from '../DateRange';
 import renderer from 'react-test-renderer';
 
 let testRenderer = null;
 let instance = null;
-const endDate = dayjs();
+const endDate = dayjs().utc(true);
 const startDate = endDate.subtract(7, 'day');
 
 const commonProps = {

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -72,7 +72,6 @@ const [state, setState] = useState({
 
 <DateRangePicker
   onChange={item => {
-    console.log('item:', item);
     setState({ ...state, ...item })
   }}
   minDate={dayjs().utc(true).subtract(20, 'day')}

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -8,8 +8,8 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState([
   {
-    startDate: dayjs(),
-    endDate: dayjs().add(7, 'day'),
+    startDate: dayjs().utc(true),
+    endDate: dayjs().utc(true).add(7, 'day'),
     key: 'selection'
   }
 ]);
@@ -32,8 +32,8 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState([
   {
-    startDate: dayjs(),
-    endDate: dayjs().add(7, 'day'),
+    startDate: dayjs().utc(true),
+    endDate: dayjs().utc(true).add(7, 'day'),
     key: 'selection'
   }
 ]);
@@ -50,6 +50,37 @@ const [state, setState] = useState([
 />;
 ```
 
+
+#### Example: Max Date and Min Date
+
+```jsx inside Markdown
+import { useState } from 'react';
+import dayjs from 'dayjs';
+
+const [state, setState] = useState({
+  selection: {
+    startDate: dayjs().utc(true),
+    endDate: dayjs().utc(true),
+    key: 'selection'
+  },
+  compare: {
+    startDate: dayjs().utc(true).subtract(1, 'day'),
+    endDate: dayjs().utc(true).subtract(1, 'day'),
+    key: 'compare'
+  }
+});
+
+<DateRangePicker
+  onChange={item => {
+    console.log('item:', item);
+    setState({ ...state, ...item })
+  }}
+  minDate={dayjs().utc(true).subtract(20, 'day')}
+  maxDate={dayjs().utc(true)}
+  ranges={[state.selection, state.compare]}
+/>;
+```
+
 #### Example: Vertical Infinite
 
 ```jsx inside Markdown
@@ -58,13 +89,13 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection: {
-    startDate: dayjs(),
+    startDate: dayjs().utc(true),
     endDate: null,
     key: 'selection'
   },
   compare: {
-    startDate: dayjs(),
-    endDate: dayjs().add(3, 'day'),
+    startDate: dayjs().utc(true),
+    endDate: dayjs().utc(true).add(3, 'day'),
     key: 'compare'
   }
 });
@@ -72,8 +103,8 @@ const [state, setState] = useState({
 <DateRangePicker
   onChange={item => setState({ ...state, ...item })}
   months={1}
-  minDate={dayjs().add(-300, 'day')}
-  maxDate={dayjs().add(900, 'day')}
+  minDate={dayjs().utc(true).add(-300, 'day')}
+  maxDate={dayjs().utc(true).add(900, 'day')}
   direction="vertical"
   scroll={{ enabled: true }}
   ranges={[state.selection, state.compare]}
@@ -88,18 +119,18 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection1: {
-    startDate: dayjs().add(1, 'day'),
+    startDate: dayjs().utc(true).add(1, 'day'),
     endDate: null,
     key: 'selection1'
   },
   selection2: {
-    startDate: dayjs().add(4, 'day'),
-    endDate: dayjs().add(8, 'day'),
+    startDate: dayjs().utc(true).add(4, 'day'),
+    endDate: dayjs().utc(true).add(8, 'day'),
     key: 'selection2'
   },
   selection3: {
-    startDate: dayjs().add(8, 'day'),
-    endDate: dayjs().add(10, 'day'),
+    startDate: dayjs().utc(true).add(8, 'day'),
+    endDate: dayjs().utc(true).add(10, 'day'),
     key: 'selection3',
     autoFocus: false
   }
@@ -119,13 +150,13 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection1: {
-    startDate: dayjs().subtract(6, 'day'),
-    endDate: dayjs(),
+    startDate: dayjs().utc(true).subtract(6, 'day'),
+    endDate: dayjs().utc(true),
     key: 'selection1'
   },
   selection2: {
-    startDate: dayjs().add(1, 'day'),
-    endDate: dayjs().subtract(7, 'day'),
+    startDate: dayjs().utc(true).add(1, 'day'),
+    endDate: dayjs().utc(true).subtract(7, 'day'),
     key: 'selection2'
   }
 });
@@ -160,13 +191,13 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection1: {
-    startDate: dayjs().subtract(6, 'day'),
-    endDate: dayjs(),
+    startDate: dayjs().utc(true).subtract(6, 'day'),
+    endDate: dayjs().utc(true),
     key: 'selection1'
   },
   selection2: {
-    startDate: dayjs().add(1, 'day'),
-    endDate: dayjs().subtract(7, 'day'),
+    startDate: dayjs().utc(true).add(1, 'day'),
+    endDate: dayjs().utc(true).subtract(7, 'day'),
     key: 'selection2'
   }
 });
@@ -227,13 +258,13 @@ import dayjs from 'dayjs';
 
 const [state, setState] = useState({
   selection: {
-    startDate: dayjs(),
+    startDate: dayjs().utc(true),
     endDate: null,
     key: 'selection'
   },
   compare: {
-    startDate: dayjs(),
-    endDate: dayjs().add(3, 'day'),
+    startDate: dayjs().utc(true),
+    endDate: dayjs().utc(true).add(3, 'day'),
     key: 'compare'
   }
 });
@@ -241,8 +272,8 @@ const [state, setState] = useState({
 <DateRangePicker
   onChange={item => setState({ ...state, ...item })}
   months={1}
-  minDate={dayjs().subtract(30, 'day')}
-  maxDate={dayjs().add(30, 'day')}
+  minDate={dayjs().utc(true).subtract(30, 'day')}
+  maxDate={dayjs().utc(true).add(30, 'day')}
   direction="vertical"
   scroll={{ enabled: true }}
   ranges={[state.selection, state.compare]}
@@ -258,7 +289,7 @@ timezone where the current date could be the next or previous date of the actual
 import { useState } from 'react';
 import dayjs from 'dayjs';
 
-const now = dayjs().add(40, 'day');
+const now = dayjs().utc(true).add(40, 'day');
 
 const [state, setState] = useState({
   selection: {
@@ -294,7 +325,7 @@ which by default is white, we can customize it by setting the `textColor` range 
 import { useState } from 'react';
 import dayjs from 'dayjs';
 
-const now = dayjs().add(40, 'day');
+const now = dayjs().utc(true).add(40, 'day');
 
 const [state, setState] = useState({
   selection: {
@@ -331,7 +362,7 @@ Disable any effect of hovering or clicking over the Calendar.
 import { useState } from 'react';
 import dayjs from 'dayjs';
 
-const now = dayjs().add(40, 'day');
+const now = dayjs().utc(true).add(40, 'day');
 
 const [state, setState] = useState({
   selection: {

--- a/src/components/DateRangePicker/index.js
+++ b/src/components/DateRangePicker/index.js
@@ -2,15 +2,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DateRange from '../DateRange';
 import DefinedRange from '../DefinedRange';
-import { findNextRangeIndex, generateStyles } from '../../utils';
+import { checkProps, findNextRangeIndex, generateStyles } from '../../utils';
 import classnames from 'classnames';
 import coreStyles from '../../styles';
-import dayjs from 'dayjs';
 import { defaultInputRanges, defaultStaticRanges } from '../../defaultRanges';
+import dayjs from '../../timeEngine';
 
 class DateRangePicker extends Component {
   constructor(props) {
     super(props);
+    checkProps(props.ranges, 'DateRangePicker');
     this.state = {
       focusedRange: [findNextRangeIndex(props.ranges), 0],
     };
@@ -18,12 +19,6 @@ class DateRangePicker extends Component {
   }
   render() {
     const { focusedRange } = this.state;
-    // All calendar calculations are based on the current date aka `now`. However, operations with dayjs() objects
-    // with timezone properties are costly and slow, visible when interacting with the UI; one hack is to do the
-    // conversion, remove the timezone and convert it back to a simple dayjs object. Here, we are removing the timezone
-    // data in case it's provided.
-    // Possible cause: https://github.com/iamkun/dayjs/issues/1236
-    const now = dayjs((this.props.now || dayjs()).format('YYYY-MM-DD'));
     return (
       <div className={classnames(this.styles.dateRangePickerWrapper, this.props.className)}>
         {<DefinedRange
@@ -36,9 +31,8 @@ class DateRangePicker extends Component {
           {...this.props}
           range={this.props.ranges[focusedRange[0]]}
           className={undefined}
-          now={now}
-          inputRanges={defaultInputRanges(now)}
-          staticRanges={defaultStaticRanges(now)}
+          inputRanges={defaultInputRanges(this.props.now)}
+          staticRanges={defaultStaticRanges(this.props.now)}
         />}
         <DateRange
           onRangeFocusChange={focusedRange => this.setState({ focusedRange })}
@@ -46,7 +40,6 @@ class DateRangePicker extends Component {
           {...this.props}
           ref={t => (this.dateRange = t)}
           className={undefined}
-          now={now}
         />
       </div>
     );
@@ -54,7 +47,9 @@ class DateRangePicker extends Component {
 }
 
 DateRangePicker.defaultProps = {
-  now: dayjs(),
+  now: dayjs().utc(true),
+  maxDate: dayjs().utc(true).add(20, 'year'),
+  minDate: dayjs().utc(true).subtract(100, 'year'),
 };
 
 DateRangePicker.propTypes = {

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -215,7 +215,6 @@ export const rangeShape = PropTypes.shape({
   autoFocus: PropTypes.bool,
   disabled: PropTypes.bool,
   showDateDisplay: PropTypes.bool,
-  readOnly: false,
 });
 
 DayCell.propTypes = {

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -1,15 +1,9 @@
 /* eslint-disable no-fallthrough */
 import classnames from 'classnames';
-import dayjs from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import dayjs from '../../timeEngine';
 
-dayjs.extend(isSameOrBefore);
-dayjs.extend(isSameOrAfter);
-dayjs.extend(isoWeek);
 class DayCell extends Component {
   constructor(props, context) {
     super(props, context);

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -7,10 +7,7 @@ import dayjs from '../../timeEngine';
 class DayCell extends Component {
   constructor(props, context) {
     super(props, context);
-
-    this.state = {
-      active: false,
-    };
+    this.active = React.createRef(false);
   }
 
   handleKeyEvent = event => {
@@ -22,8 +19,7 @@ class DayCell extends Component {
     }
   };
   handleMouseEvent = event => {
-    const { day, disabled, onPreviewChange, onMouseEnter, onMouseDown, onMouseUp, readOnly } = this.props;
-    const stateChanges = {};
+    const { day, disabled, onPreviewChange, onMouseEnter, onMouseDown, onMouseUp, readOnly, selecting } = this.props;
     if (disabled) {
       onPreviewChange();
       return;
@@ -37,20 +33,17 @@ class DayCell extends Component {
         break;
       case 'mousedown':
         if (readOnly) break;
-        stateChanges.active = true;
-        onMouseDown(day);
+        this.active.current = true;
+        !selecting && onMouseDown(day);
         break;
       case 'mouseup':
         event.stopPropagation();
-        stateChanges.active = false;
+        this.active.current = false;
         !readOnly && onMouseUp(day);
         break;
       case 'focus':
         !readOnly && onPreviewChange(day);
         break;
-    }
-    if (Object.keys(stateChanges).length) {
-      this.setState(stateChanges);
     }
   };
   getClassNames = () => {
@@ -74,7 +67,7 @@ class DayCell extends Component {
       [styles.dayEndOfWeek]: isEndOfWeek,
       [styles.dayStartOfMonth]: isStartOfMonth,
       [styles.dayEndOfMonth]: isEndOfMonth,
-      [styles.dayActive]: this.state.active,
+      [styles.dayActive]: this.active.current,
       [styles.dayReadOnly]: this.props.readOnly,
     });
   };
@@ -191,7 +184,8 @@ class DayCell extends Component {
 }
 
 DayCell.defaultProps = {
-  now: dayjs(),
+  now: dayjs().utc(true),
+  selecting: false,
 };
 
 export const rangeShape = PropTypes.shape({
@@ -234,6 +228,7 @@ DayCell.propTypes = {
   dayContentRenderer: PropTypes.func,
   now: PropTypes.object,
   readOnly: PropTypes.bool,
+  selecting: PropTypes.bool,
 };
 
 export default DayCell;

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -9,7 +9,6 @@ class DayCell extends Component {
     super(props, context);
 
     this.state = {
-      hover: false,
       active: false,
     };
   }
@@ -35,11 +34,6 @@ class DayCell extends Component {
         if (readOnly) break;
         onMouseEnter(day);
         onPreviewChange(day);
-        stateChanges.hover = true;
-        break;
-      case 'blur':
-      case 'mouseleave':
-        stateChanges.hover = false;
         break;
       case 'mousedown':
         if (readOnly) break;
@@ -80,7 +74,6 @@ class DayCell extends Component {
       [styles.dayEndOfWeek]: isEndOfWeek,
       [styles.dayStartOfMonth]: isStartOfMonth,
       [styles.dayEndOfMonth]: isEndOfMonth,
-      [styles.dayHovered]: this.state.hover,
       [styles.dayActive]: this.state.active,
       [styles.dayReadOnly]: this.props.readOnly,
     });

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -25,7 +25,6 @@ class DayCell extends Component {
   handleMouseEvent = event => {
     const { day, disabled, onPreviewChange, onMouseEnter, onMouseDown, onMouseUp, readOnly } = this.props;
     const stateChanges = {};
-    if (readOnly) return;
     if (disabled) {
       onPreviewChange();
       return;
@@ -33,6 +32,7 @@ class DayCell extends Component {
 
     switch (event.type) {
       case 'mouseenter':
+        if (readOnly) break;
         onMouseEnter(day);
         onPreviewChange(day);
         stateChanges.hover = true;
@@ -42,16 +42,17 @@ class DayCell extends Component {
         stateChanges.hover = false;
         break;
       case 'mousedown':
+        if (readOnly) break;
         stateChanges.active = true;
         onMouseDown(day);
         break;
       case 'mouseup':
         event.stopPropagation();
         stateChanges.active = false;
-        onMouseUp(day);
+        !readOnly && onMouseUp(day);
         break;
       case 'focus':
-        onPreviewChange(day);
+        !readOnly && onPreviewChange(day);
         break;
     }
     if (Object.keys(stateChanges).length) {

--- a/src/components/DayCell/index.scss
+++ b/src/components/DayCell/index.scss
@@ -10,6 +10,20 @@
   cursor: default;
 }
 
+.rdrCalendarWrapper:not(.rdrCalendarWrapper--dragging) .rdrDay {
+  &:not(.rdrDayDisabled):hover .rdrDayNumber:after{
+    content: '';
+    border: 1px solid currentColor;
+    border-radius: 1.333em;
+    position: absolute;
+    top: -2px;
+    bottom: -2px;
+    left: 0px;
+    right: 0px;
+    background: transparent;
+  }
+}
+
 .rdrDayNumber {
   display: block;
   position: relative;
@@ -37,7 +51,5 @@
 .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview{
   pointer-events: none;
 }
-
-.rdrDayHovered{}
 
 .rdrDayActive{}

--- a/src/components/DayCell/index.scss
+++ b/src/components/DayCell/index.scss
@@ -10,7 +10,7 @@
   cursor: default;
 }
 
-.rdrCalendarWrapper:not(.rdrCalendarWrapper--dragging) .rdrDay {
+.rdrCalendarWrapper:not(.rdrCalendarWrapper--selecting) .rdrDay {
   &:not(.rdrDayDisabled):hover .rdrDayNumber:after{
     content: '';
     border: 1px solid currentColor;

--- a/src/components/DefinedRange/__snapshots__/index.test.js.snap
+++ b/src/components/DefinedRange/__snapshots__/index.test.js.snap
@@ -119,6 +119,7 @@ exports[`DefinedRange tests Should render dynamic static label contents correctl
       styles={
         Object {
           "calendarWrapper": "rdrCalendarWrapper",
+          "calendarWrapperDragging": "rdrCalendarWrapper--dragging",
           "dateDisplay": "rdrDateDisplay",
           "dateDisplayItem": "rdrDateDisplayItem",
           "dateDisplayItemActive": "rdrDateDisplayItemActive",
@@ -131,7 +132,6 @@ exports[`DefinedRange tests Should render dynamic static label contents correctl
           "dayEndOfMonth": "rdrDayEndOfMonth",
           "dayEndOfWeek": "rdrDayEndOfWeek",
           "dayEndPreview": "rdrDayEndPreview",
-          "dayHovered": "rdrDayHovered",
           "dayInPreview": "rdrDayInPreview",
           "dayNumber": "rdrDayNumber",
           "dayPassive": "rdrDayPassive",
@@ -184,6 +184,7 @@ exports[`DefinedRange tests Should render dynamic static label contents correctl
       styles={
         Object {
           "calendarWrapper": "rdrCalendarWrapper",
+          "calendarWrapperDragging": "rdrCalendarWrapper--dragging",
           "dateDisplay": "rdrDateDisplay",
           "dateDisplayItem": "rdrDateDisplayItem",
           "dateDisplayItemActive": "rdrDateDisplayItemActive",
@@ -196,7 +197,6 @@ exports[`DefinedRange tests Should render dynamic static label contents correctl
           "dayEndOfMonth": "rdrDayEndOfMonth",
           "dayEndOfWeek": "rdrDayEndOfWeek",
           "dayEndPreview": "rdrDayEndPreview",
-          "dayHovered": "rdrDayHovered",
           "dayInPreview": "rdrDayInPreview",
           "dayNumber": "rdrDayNumber",
           "dayPassive": "rdrDayPassive",

--- a/src/components/DefinedRange/index.js
+++ b/src/components/DefinedRange/index.js
@@ -138,8 +138,8 @@ DefinedRange.propTypes = {
 };
 
 DefinedRange.defaultProps = {
-  inputRanges: defaultInputRanges(dayjs()),
-  staticRanges: defaultStaticRanges(dayjs()),
+  inputRanges: defaultInputRanges(dayjs().utc(true)),
+  staticRanges: defaultStaticRanges(dayjs().utc(true)),
   ranges: [],
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   focusedRange: [0, 0],

--- a/src/components/DefinedRange/index.js
+++ b/src/components/DefinedRange/index.js
@@ -5,7 +5,7 @@ import { defaultInputRanges, defaultStaticRanges } from '../../defaultRanges';
 import { rangeShape } from '../DayCell';
 import InputRangeField from '../InputRangeField';
 import cx from 'classnames';
-import dayjs from 'dayjs';
+import dayjs from '../../timeEngine';
 
 class DefinedRange extends Component {
   constructor(props) {

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -1,15 +1,9 @@
 /* eslint-disable no-fallthrough */
-import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import weekday from 'dayjs/plugin/weekday';
-import updateLocale from 'dayjs/plugin/updateLocale';
-
 import { getMonthDisplayRange, getIntervals } from '../../utils';
 import DayCell, { rangeShape } from '../DayCell';
-
-dayjs.extend(weekday);
-dayjs.extend(updateLocale);
+import dayjs from '../../timeEngine';
 
 function renderWeekdays(now, styles) {
   const startOfWeek = now.startOf('week');
@@ -78,7 +72,7 @@ class Month extends PureComponent {
                 day={day}
                 now={now}
                 preview={showPreview ? this.props.preview : null}
-                isWeekend={day.weekday() == 7 || day.weekday() == 6}
+                isWeekend={day.day() == 0 || day.day() == 6}
                 isToday={day.isSame(now, 'day')}
                 isStartOfWeek={day.isSame(day.startOf('week'), 'day')}
                 isEndOfWeek={day.isSame(day.endOf('week'), 'day')}

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -3,20 +3,22 @@ import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import weekday from 'dayjs/plugin/weekday';
+import updateLocale from 'dayjs/plugin/updateLocale';
 
 import { getMonthDisplayRange, getIntervals } from '../../utils';
 import DayCell, { rangeShape } from '../DayCell';
 
 dayjs.extend(weekday);
-// eslint-disable-next-line no-unused-vars
-function renderWeekdays(now, styles, _dateOptions, _weekdayDisplayFormat) {
-  const startOfWeek = now.startOf('isoWeek');
-  const endOfWeek = now.endOf('isoWeek');
+dayjs.extend(updateLocale);
+
+function renderWeekdays(now, styles) {
+  const startOfWeek = now.startOf('week');
+  const endOfWeek = now.endOf('week');
   return (
     <div className={styles.weekDays}>
       {getIntervals(startOfWeek, endOfWeek).map((day, i) => (
         <span className={styles.weekDay} key={i}>
-          {dayjs.weekdaysShort()[day.weekday()]}
+          {dayjs.weekdaysShort()[day.day()]}
         </span>
       ))}
     </div>
@@ -25,7 +27,14 @@ function renderWeekdays(now, styles, _dateOptions, _weekdayDisplayFormat) {
 
 class Month extends PureComponent {
   render() {
-    const { displayMode, focusedRange, drag, styles, disabledDates, disabledDay, now } = this.props;
+    const { displayMode, focusedRange, drag, styles, disabledDates, disabledDay, now, dateOptions } = this.props;
+    if (dateOptions.weekStartsOn != null) {
+      dayjs.updateLocale(dateOptions.locale, {
+        weekStart: dateOptions.weekStartsOn,
+      });
+      now.$locale().weekStart = dateOptions.weekStartsOn;
+    }
+    dayjs.locale(dateOptions.locale);
     const minDate = this.props.minDate?.startOf('day');
     const maxDate = this.props.maxDate?.endOf('day');
     const monthDisplay = getMonthDisplayRange(
@@ -51,13 +60,7 @@ class Month extends PureComponent {
         {this.props.showMonthName ? (
           <div className={styles.monthName}>{dayjs.months()[this.props.month.month()]}</div>
         ) : null}
-        {this.props.showWeekDays &&
-          renderWeekdays(
-            now,
-            styles,
-            this.props.dateOptions,
-            this.props.weekdayDisplayFormat,
-          )}
+        {this.props.showWeekDays && renderWeekdays(now, styles)}
         <div className={styles.days} onMouseLeave={this.props.onMouseLeave}>
           {getIntervals(monthDisplay.start, monthDisplay.end).map((day, index) => {
             const isStartOfMonth = day.isSame(monthDisplay.startDateOfMonth, 'day');
@@ -75,10 +78,10 @@ class Month extends PureComponent {
                 day={day}
                 now={now}
                 preview={showPreview ? this.props.preview : null}
-                isWeekend={day.isoWeekday() == 7 || day.isoWeekday() == 6}
+                isWeekend={day.weekday() == 7 || day.weekday() == 6}
                 isToday={day.isSame(now, 'day')}
-                isStartOfWeek={day.isSame(day.startOf('isoWeek'), 'day')}
-                isEndOfWeek={day.isSame(day.endOf('isoWeek'), 'day')}
+                isStartOfWeek={day.isSame(day.startOf('week'), 'day')}
+                isEndOfWeek={day.isSame(day.endOf('week'), 'day')}
                 isStartOfMonth={isStartOfMonth}
                 isEndOfMonth={isEndOfMonth}
                 key={index}

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -93,6 +93,7 @@ class Month extends PureComponent {
                 onMouseEnter={this.props.onDragSelectionMove}
                 dragRange={drag.range}
                 drag={drag.status}
+                selecting={this.props.selecting}
               />
             );
           })}
@@ -105,6 +106,7 @@ class Month extends PureComponent {
 Month.defaultProps = {
   now: dayjs(),
   readOnly: false,
+  selecting: false,
 };
 
 Month.propTypes = {
@@ -137,6 +139,7 @@ Month.propTypes = {
   fixedHeight: PropTypes.bool,
   now: PropTypes.object,
   readOnly: PropTypes.bool,
+  selecting: PropTypes.bool,
 };
 
 export default Month;

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -104,7 +104,7 @@ class Month extends PureComponent {
 }
 
 Month.defaultProps = {
-  now: dayjs(),
+  now: dayjs().utc(true),
   readOnly: false,
   selecting: false,
 };

--- a/src/defaultRanges.js
+++ b/src/defaultRanges.js
@@ -1,14 +1,14 @@
 import dayjs from 'dayjs';
 
 const defineds = (now = dayjs()) => ({
-  startOfWeek: now.startOf('isoWeek'),
-  endOfWeek: now.endOf('isoWeek'),
+  startOfWeek: now.startOf('week'),
+  endOfWeek: now.endOf('week'),
   startOfLastWeek: now
     .subtract(7, 'day')
     .startOf('day'),
   endOfLastWeek: now
     .subtract(7, 'day')
-    .endOf('isoWeek'),
+    .endOf('week'),
   startOfToday: now.startOf('day'),
   endOfToday: now.endOf('day'),
   startOfYesterday: now

--- a/src/defaultRanges.js
+++ b/src/defaultRanges.js
@@ -1,6 +1,6 @@
-import dayjs from 'dayjs';
+import dayjs from './timeEngine';
 
-const defineds = (now = dayjs()) => ({
+const defineds = (now = dayjs().utc(true)) => ({
   startOfWeek: now.startOf('week'),
   endOfWeek: now.endOf('week'),
   startOfLastWeek: now
@@ -42,7 +42,7 @@ export function createStaticRanges(ranges) {
   return ranges.map(range => ({ ...staticRangeHandler, ...range }));
 }
 
-export const defaultStaticRanges = (now = dayjs()) => ((defineds) => createStaticRanges([
+export const defaultStaticRanges = (now = dayjs().utc(true)) => ((defineds) => createStaticRanges([
   {
     label: 'Today',
     range: () => ({
@@ -88,7 +88,7 @@ export const defaultStaticRanges = (now = dayjs()) => ((defineds) => createStati
   },
 ]))(defineds(now));
 
-export const defaultInputRanges = (now = dayjs()) => ((defineds) => [
+export const defaultInputRanges = (now = dayjs().utc(true)) => ((defineds) => [
   {
     label: 'days up to today',
     range(value) {
@@ -106,7 +106,7 @@ export const defaultInputRanges = (now = dayjs()) => ((defineds) => [
   {
     label: 'days starting today',
     range(value) {
-      const today = dayjs();
+      const today = dayjs().utc(true);
       return {
         startDate: today,
         endDate: today.add(Math.max(Number(value), 1) - 1, 'day'),

--- a/src/styles.js
+++ b/src/styles.js
@@ -25,7 +25,6 @@ export default {
   dayStartPreview: 'rdrDayStartPreview',
   dayInPreview: 'rdrDayInPreview',
   dayEndPreview: 'rdrDayEndPreview',
-  dayHovered: 'rdrDayHovered',
   dayActive: 'rdrDayActive',
   dayReadOnly: 'rdrDayReadOnly',
   inRange: 'rdrInRange',
@@ -51,4 +50,5 @@ export default {
   infiniteMonths: 'rdrInfiniteMonths',
   monthsVertical: 'rdrMonthsVertical',
   monthsHorizontal: 'rdrMonthsHorizontal',
+  calendarWrapperDragging: 'rdrCalendarWrapper--dragging',
 };

--- a/src/styles.js
+++ b/src/styles.js
@@ -50,5 +50,5 @@ export default {
   infiniteMonths: 'rdrInfiniteMonths',
   monthsVertical: 'rdrMonthsVertical',
   monthsHorizontal: 'rdrMonthsHorizontal',
-  calendarWrapperDragging: 'rdrCalendarWrapper--dragging',
+  calendarWrapperSelecting: 'rdrCalendarWrapper--selecting',
 };

--- a/src/theme/default.scss
+++ b/src/theme/default.scss
@@ -375,18 +375,6 @@
   }
 }
 
-.rdrCalendarWrapper:not(.rdrDateRangeWrapper) .rdrDayHovered .rdrDayNumber:after{
-  content: '';
-  border: 1px solid currentColor;
-  border-radius: 1.333em;
-  position: absolute;
-  top: -2px;
-  bottom: -2px;
-  left: 0px;
-  right: 0px;
-  background: transparent;
-}
-
 .rdrDayPassive{
   pointer-events: none;
   .rdrDayNumber span{

--- a/src/timeEngine.js
+++ b/src/timeEngine.js
@@ -1,0 +1,34 @@
+import 'dayjs/locale/de';
+import 'dayjs/locale/es';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/it';
+import 'dayjs/locale/ja';
+import 'dayjs/locale/nl';
+import 'dayjs/locale/pt';
+import 'dayjs/locale/ru';
+import dayjs from 'dayjs';
+import localeData from 'dayjs/plugin/localeData';
+import utc from 'dayjs/plugin/utc';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import minMax from 'dayjs/plugin/minMax';
+import updateLocale from 'dayjs/plugin/updateLocale';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isBetween from 'dayjs/plugin/isBetween';
+import weekday from 'dayjs/plugin/weekday';
+
+dayjs.extend(isBetween);
+dayjs.extend(isSameOrBefore);
+dayjs.extend(isSameOrAfter);
+dayjs.extend(isoWeek);
+dayjs.extend(weekday);
+dayjs.extend(localeData);
+dayjs.extend(minMax);
+dayjs.extend(localizedFormat);
+dayjs.extend(updateLocale);
+dayjs.extend(utc);
+
+
+export { dayjs };
+export default dayjs;

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,8 +43,8 @@ export function findNextRangeIndex(ranges, currentRangeIndex = -1) {
 export function getMonthDisplayRange(date, dateOptions, fixedHeight) {
   const startDateOfMonth = date.startOf('month');
   const endDateOfMonth = date.endOf('month');
-  const startDateOfCalendar = startDateOfMonth.startOf('isoWeek');
-  let endDateOfCalendar = endDateOfMonth.endOf('isoWeek');
+  const startDateOfCalendar = startDateOfMonth.startOf('week');
+  let endDateOfCalendar = endDateOfMonth.endOf('week');
   if (fixedHeight && endDateOfCalendar.diff(startDateOfCalendar, 'day') <= 34) {
     endDateOfCalendar = endDateOfCalendar.add(7, 'day');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,3 +80,17 @@ export function getIntervals(currentDay, closeDay) {
   }
   return dateRanges;
 }
+
+export function checkRanges(ranges, component) {
+  ranges.forEach((range) => {
+    if(range.startDate && !range.startDate.isUTC()) throw new Error('Invalid range `startDate` UTC dayjs object at ' + component);
+    if(range.endDate && !range.endDate.isUTC()) throw new Error('Invalid range `endDate` UTC dayjs object at' + component);
+  });
+}
+
+export function checkProps(props, component) {
+  if(props.now && !props.now.isUTC()) throw new Error('Invalid `now` UTC dayjs object at' + component);
+  if(props.maxDate && !props.maxDate.isUTC()) throw new Error('Invalid `maxDate` UTC dayjs object at ' + component);
+  if(props.minDate && !props.minDate.isUTC()) throw new Error('Invalid `minDate` UTC dayjs object at ' + component);
+  if(props.ranges) checkRanges(props.ranges, component);
+}


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
- 🐛Fix weekStartOn customization.
- 🐛💥 Accept only dayjs UTC objects for consistency and WYSIWYG.
- 🐛Fix readOnly event listener to allow blur.
- ⚡Apply day cell hover state only via CSS, parent class and pseudo-class.
- 🐛💄Fix glitch when selecting end of range.

About the breaking change, more details in the commit, but to avoid edge cases and be a bit agnostic of user dayjs(), better to treat everything as UTC and use a custom `now` (property already available) as the reference for calculations. Many edge cases were about users watching one day before/after the current one, because not everything was UTC or having the same offset.

:warning:  _As the current code is legacy React, is a bit difficult to transform the input props as they are immutable, and using new state properties will involve many changes._

For easy of usage and consistency, we advise to use `.utc(true)` or `utc({...})` with `ObjectSupport` plugin, so you can keep the `what you see` date.

In new versions, we can be agnostic of the user library and accept a single json object or string for dates:
e.g. `now="2023-11-11"` or better for i18n `now={{ year: 2023, month: 10, day: 11 }}`

```
// my local timezone: Europe/Paris UTC+1

dayjs("2022-02-04").utc(true).format() 
// ✅ dayjs will keep your declared date but as UTC
// '2022-02-04T00:00:00Z'

dayjs.utc({ y:2022, M:2, d:4, h: 20}).format()
// ✅ dayjs will keep your declared date but as UTC
// *remember that ObjectSupport uses 0 as index for months
// '2022-03-04T20:00:00Z'

dayjs().format() 
// '2023-11-18T19:59:35+01:00'

dayjs.utc().format() 
// ❌ UTC but dayjs applies the offset
// '2023-11-18T18:57:09Z'

dayjs().utc().format() 
// ❌ UTC but dayjs applies the offset
// '2023-11-18T18:57:09Z'

dayjs().utc(true).format()
//  ✅ same time as my local one
// '2023-11-18T19:57:36Z'

dayjs("2022-02-04").utc().format() 
// ❌ dayjs will apply the offset of your local timezone
// so the calendar would render other day
// '2022-02-03T23:00:00Z'

dayjs("2022-02-04T20:00:00").utc().format() 
// ❌ We don´t care about hours but dayjs will still apply the offset when parsing it
// '2022-02-04T19:00:00Z'

dayjs().utc().format()
// ❌ this will take the current time and apply the offset 
// so the calendar would render other day depending on the timezone and the time when it was called

dayjs("2022-02-04")
// ❌ it's still non UTC
// dayjs("2022-10-10").format()
// '2022-10-10T00:00:00+02:00'

dayjs("2022-02-04").tz("UTC")
// ❌ buggy, don´t do it. https://github.com/iamkun/dayjs/issues/2507
// 💥 it adds also timezone data to the object ($x: {$timezone: 'UTC'}) making the calendars super laggy because of time operations checking it
```
