### PR TITLE
🐛💄 Avoid double border when hovering over day cells.

### DIFF
--- a/src/components/DayCell/index.scss
+++ b/src/components/DayCell/index.scss
@@ -11,16 +11,24 @@
 }
 
 .rdrCalendarWrapper:not(.rdrCalendarWrapper--selecting) .rdrDay {
-  &:not(.rdrDayDisabled):hover .rdrDayNumber:after{
-    content: '';
-    border: 1px solid currentColor;
-    border-radius: 1.333em;
-    position: absolute;
-    top: -2px;
-    bottom: -2px;
-    left: 0px;
-    right: 0px;
-    background: transparent;
+  &:not(.rdrDayDisabled):hover {
+
+    .rdrDayNumber:after{
+      content: '';
+      border: 1px solid currentColor;
+      border-radius: 1.333em;
+      position: absolute;
+      top: -2px;
+      bottom: -2px;
+      left: 0px;
+      right: 0px;
+      background: transparent;
+    }
+
+    .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview{
+      display: none;
+    }
+
   }
 }
 


### PR DESCRIPTION
- :hover was adding a border.
- .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview are also created even when hovering over a day cell, and they were with border.
- As we are already showing a border with :hover, let's hide the .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview one, only is hovering to about double ones which in UI seems blurry.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
