### PR TITLE
New `selectorColor` range property and bug fixes

### DIFF
--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -436,7 +436,7 @@ class Calendar extends PureComponent {
     return (
       <div
         className={classnames(this.styles.calendarWrapper, className, {
-          [styles.calendarWrapperSelecting]: this.state.selecting,
+          [styles.calendarWrapperSelecting]: this.state.selecting || this.props.preview?.predefined,
         })}
         onMouseUp={() => {
           if (readOnly) return;
@@ -607,6 +607,7 @@ Calendar.propTypes = {
     startDate: PropTypes.object,
     endDate: PropTypes.object,
     color: PropTypes.string,
+    predefined: PropTypes.bool,
   }),
   dateDisplayFormat: PropTypes.string,
   monthDisplayFormat: PropTypes.string,

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -107,7 +107,7 @@ class DateRange extends Component {
     this.setState({ focusedRange });
     this.props.onRangeFocusChange && this.props.onRangeFocusChange(focusedRange);
   };
-  updatePreview = val => {
+  updatePreview = (val, predefined) => {
     if (!val) {
       this.setState({ preview: null });
       return;
@@ -115,7 +115,7 @@ class DateRange extends Component {
     const { rangeColors, ranges } = this.props;
     const focusedRange = this.props.focusedRange || this.state.focusedRange;
     const color = ranges[focusedRange[0]]?.color || rangeColors[focusedRange[0]] || color;
-    this.setState({ preview: { ...val.range, color } });
+    this.setState({ preview: { ...val.range, color, predefined } });
   };
   render() {
     return (

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -353,6 +353,49 @@ const [state, setState] = useState({
 />;
 ```
 
+
+#### Example: Custom range selectorColor
+
+When setting the dates for a range, sometimes we need better contrast between the color and the
+border line that appears when hovering over the calendar days which by default is the same color
+as the range color, we can customize it by setting the `selectorColor` range property.
+
+```jsx inside Markdown
+import { useState } from 'react';
+import dayjs from 'dayjs';
+
+const now = dayjs().utc(true).add(40, 'day');
+
+const [state, setState] = useState({
+  selection: {
+    startDate: now,
+    endDate: now.add(3, 'day'),
+    key: 'selection',
+    color: 'red',
+    textColor: 'white',
+    selectorColor: 'green'
+  },
+  compare: {
+    startDate: now.subtract(1, 'week'),
+    endDate: now.add(3, 'day').subtract(1, 'week'),
+    key: 'compare',
+    textColor: 'black',
+    color: '#EEE'
+  }
+});
+
+<DateRangePicker
+  onChange={item => setState({ ...state, ...item })}
+  months={1}
+  scroll={{ enabled: false }}
+  direction="vertical"
+  minDate={now.subtract(50, 'day')}
+  maxDate={now.add(30, 'day')}
+  ranges={[state.selection, state.compare]}
+  now={now}
+/>;
+```
+
 #### Example: Read-Only
 
 Disable any effect of hovering or clicking over the Calendar.

--- a/src/components/DateRangePicker/index.js
+++ b/src/components/DateRangePicker/index.js
@@ -26,7 +26,8 @@ class DateRangePicker extends Component {
             focusedRange={focusedRange}
             onPreviewChange={value =>
               this.dateRange.updatePreview(
-                value ? this.dateRange.calcNewSelection(value, typeof value === 'string') : null
+                value ? this.dateRange.calcNewSelection(value, typeof value === 'string') : null,
+                true
               )
             }
             {...this.props}

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -81,7 +81,7 @@ class DayCell extends Component {
     });
   };
   renderPreviewPlaceholder = () => {
-    const { preview, day, styles } = this.props;
+    const { preview, day, styles, focusedRange } = this.props;
     if (!preview) return null;
     if (preview.startDate.isAfter(preview.endDate)) {
       const start = preview.startDate;
@@ -100,7 +100,7 @@ class DayCell extends Component {
           [styles.dayInPreview]: isInRange,
           [styles.dayEndPreview]: isEndEdge,
         })}
-        style={{ color: preview.color }}
+        style={{ color: focusedRange.selectorColor || preview.color }}
       />
     );
   };
@@ -164,7 +164,7 @@ class DayCell extends Component {
   };
 
   render() {
-    const { dayContentRenderer } = this.props;
+    const { dayContentRenderer, focusedRange } = this.props;
     return (
       <button
         type="button"
@@ -179,7 +179,7 @@ class DayCell extends Component {
         onKeyUp={this.handleKeyEvent}
         className={this.getClassNames(this.props.styles)}
         {...(this.props.disabled || this.props.isPassive ? { tabIndex: -1 } : {})}
-        style={{ color: this.props.color }}>
+        style={{ color: focusedRange.selectorColor || focusedRange.color || this.props.color }}>
         {this.renderSelectionPlaceholders()}
         {this.renderPreviewPlaceholder()}
         <span className={this.props.styles.dayNumber}>
@@ -202,6 +202,7 @@ export const rangeShape = PropTypes.shape({
   endDate: PropTypes.object,
   color: PropTypes.string,
   textColor: PropTypes.string,
+  selectorColor: PropTypes.string,
   key: PropTypes.string,
   autoFocus: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -213,6 +214,7 @@ DayCell.propTypes = {
   dayDisplayFormat: PropTypes.string,
   date: PropTypes.object,
   ranges: PropTypes.arrayOf(rangeShape),
+  focusedRange: rangeShape,
   preview: PropTypes.shape({
     startDate: PropTypes.object,
     endDate: PropTypes.object,

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -78,6 +78,7 @@ class Month extends PureComponent {
               <DayCell
                 {...this.props}
                 ranges={ranges}
+                focusedRange={ranges[this.props.focusedRange[0]]}
                 day={day}
                 now={now}
                 preview={showPreview ? this.props.preview : null}

--- a/src/defaultRanges.js
+++ b/src/defaultRanges.js
@@ -97,7 +97,7 @@ export const defaultInputRanges = (now = dayjs().utc(true)) =>
     {
       label: 'days starting today',
       range(value) {
-        const today = dayjs().utc(true);
+        const today = now;
         return {
           startDate: today,
           endDate: today.add(Math.max(Number(value), 1) - 1, 'day'),

--- a/src/theme/default.scss
+++ b/src/theme/default.scss
@@ -279,41 +279,44 @@
  }
 }
 
-.rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview{
-  background: rgba(255, 255, 255, 0.09);
-  position: absolute;
-  top: 3px;
-  left: 0px;
-  right: 0px;
-  bottom: 3px;
-  pointer-events: none;
-  border: 0px solid currentColor;
-  z-index: 1;
-}
+.rdrCalendarWrapper--selecting {
 
+  .rdrDayStartPreview, .rdrDayInPreview, .rdrDayEndPreview{
+    background: rgba(255, 255, 255, 0.09);
+    position: absolute;
+    top: 3px;
+    left: 0px;
+    right: 0px;
+    bottom: 3px;
+    pointer-events: none;
+    border: 0px solid currentColor;
+    z-index: 1;
+  }
 
-.rdrDayStartPreview{
-  border-top-width: 1px;
-  border-left-width: 1px;
-  border-bottom-width: 1px;
-  border-top-left-radius: 1.333em;
-  border-bottom-left-radius: 1.333em;
-  left: 0px;
-}
+  .rdrDayStartPreview{
+    border-top-width: 1px;
+    border-left-width: 1px;
+    border-bottom-width: 1px;
+    border-top-left-radius: 1.333em;
+    border-bottom-left-radius: 1.333em;
+    left: 0px;
+  }
 
-.rdrDayInPreview{
-  border-top-width: 1px;
-  border-bottom-width: 1px;
-}
+  .rdrDayInPreview{
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
 
-.rdrDayEndPreview{
-  border-top-width: 1px;
-  border-right-width: 1px;
-  border-bottom-width: 1px;
-  border-top-right-radius: 1.333em;
-  border-bottom-right-radius: 1.333em;
-  right: 2px;
-  right: 0px;
+  .rdrDayEndPreview{
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-top-right-radius: 1.333em;
+    border-bottom-right-radius: 1.333em;
+    right: 2px;
+    right: 0px;
+  }
+
 }
 
 .rdrDefinedRangesWrapper{


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

- [🐛Fix DayCell blur](https://github.com/tolares/react-date-range-dayjs/commit/ff057eac6ecbca203fef5172a45cb18ca1b9cb93)
- [✨Add selectorColor property to ranges](https://github.com/tolares/react-date-range-dayjs/commit/75b0ab4c78dbe68034a3141c2173ad8b0e57292b)

New feature is to add custom color to the hover selector, so we can use black as the current datepicker.

![image](https://github.com/tolares/react-date-range-dayjs/assets/1231888/4f0ec7fc-c30c-407a-ac40-97c2dd4fc879)
